### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Installation:
 Run:
 ==
 ```
-$ ./go-nagios-api --port=9090 --cachefile=/opt/nagios/object.cache --statusfile=/opt/nagios/status.dat --commandfile=/opt/nagios/nagios.cmd
+$ ./go-nagios-api --addr=:9090 --cachefile=/opt/nagios/object.cache --statusfile=/opt/nagios/status.dat --commandfile=/opt/nagios/nagios.cmd
 
 Or you can provide a configuration file with these parameter in json format (configuration file overwrites cli flags)
 
 $ ./go-nagios-api --config=nagios-api.json
 ```
-It will start the api service on port 8080. If you wish to change the port simply pass --port=80 to make it run on port 80. For running in production see init scripts.
+It will start the api service on port 8080. If you wish to change the port simply pass --addr=:80 to make it run on port 80. For running in production see init scripts.
 
 API Calls
 ==

--- a/api/api.go
+++ b/api/api.go
@@ -54,24 +54,30 @@ type ContactStatus struct {
 }
 
 func init() {
-	readObjectCache()
+	err := readObjectCache()
+	if err != nil {
+		log.Fatal("Unable to parse object cache file: ", err)
+	}
 	go spawnRefreshRoutein()
 }
 
 func spawnRefreshRoutein() {
 	for {
-		refreshStatusData()
+		err := refreshStatusData()
+		if err != nil {
+			log.Println("Unable to refresh status data: ", err)
+		}
 		time.Sleep(60 * time.Second)
 	}
 }
 
-func readObjectCache() {
+func readObjectCache() error {
 	conf := config.GetConfig()
 	log.Printf("Reading object cache from %s", conf.ObjectCacheFile)
 	log.Printf("Writing commands to %s", conf.CommandFile)
 	dat, err := ioutil.ReadFile(conf.ObjectCacheFile)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	a := strings.SplitAfterN(string(dat), "}", -1)
@@ -134,14 +140,16 @@ func readObjectCache() {
 		}
 
 	}
+
+	return nil
 }
 
-func refreshStatusData() {
+func refreshStatusData() error {
 	conf := config.GetConfig()
 	log.Printf("Refreshig data from %s", conf.StatusFile)
 	dat, err := ioutil.ReadFile(conf.StatusFile)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	a := strings.SplitAfterN(string(dat), "}", -1)
@@ -185,6 +193,8 @@ func refreshStatusData() {
 			hostStatusList = append(hostStatusList, host)
 		}
 	}
+
+	return nil
 }
 
 // HandleGetContacts returns all configured contactlist

--- a/api/api.go
+++ b/api/api.go
@@ -23,10 +23,6 @@ type Api struct {
 	fileStatus      string
 	statusData      *StatusData
 	staticData      *StaticData
-	contactList     []map[string]string
-	serviceList     []map[string]string
-	hostList        []map[string]string
-	hostgroupList   []map[string]string
 	mutex           sync.RWMutex
 }
 
@@ -257,7 +253,7 @@ func refreshStatusData(fh io.Reader) (*StatusData, error) {
 // GET: /contacts
 func (a *Api) HandleGetContacts(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(a.contactList)
+	json.NewEncoder(w).Encode(a.staticData.contactList)
 }
 
 // HandleGetAllHostStatus returns hoststatus for all hosts
@@ -330,12 +326,13 @@ func (a *Api) HandleGetServiceStatusForService(w http.ResponseWriter, r *http.Re
 func (a *Api) HandleGetHost(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	host, ok := vars["hostname"]
+	log.Println(host)
 	if !ok {
 		http.Error(w, "Invalid hostname provided", 400)
 		return
 	}
 
-	for _, item := range a.hostList {
+	for _, item := range a.staticData.hostList {
 		if item["host_name"] == host {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(item)

--- a/api/command_handlers.go
+++ b/api/command_handlers.go
@@ -50,7 +50,7 @@ func (a *Api) HandleAcknowledgeHostProblem(w http.ResponseWriter, r *http.Reques
 	}
 
 	command := fmt.Sprintf("%s;%s;%d;%d;%d;%s;%s", "ACKNOWLEDGE_HOST_PROBLEM", data.Hostname, data.Sticky, data.Notify, data.Persistent, data.Author, data.Comment)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleAcknowledgeServiceProblem ACKNOWLEDGE_SVC_PROBLEM
@@ -96,7 +96,7 @@ func (a *Api) HandleAcknowledgeServiceProblem(w http.ResponseWriter, r *http.Req
 	}
 
 	command := fmt.Sprintf("%s;%s;%s;%d;%d;%d;%s;%s", "ACKNOWLEDGE_SVC_PROBLEM", data.Hostname, data.ServiceDescription, data.Sticky, data.Notify, data.Persistent, data.Author, data.Comment)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleAddHostComment ADD_HOST_COMMENT
@@ -136,7 +136,7 @@ func (a *Api) HandleAddHostComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	command := fmt.Sprintf("%s;%s;%d;%s;%s", "ADD_HOST_COMMENT", data.Hostname, data.Persistent, data.Author, data.Comment)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 
 }
 
@@ -183,7 +183,7 @@ func (a *Api) HandleAddServiceComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	command := fmt.Sprintf("%s;%s;%s;%d;%s;%s", "ADD_SVC_COMMENT", data.Hostname, data.Service, data.Persistent, data.Author, data.Comment)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDeleteAllHostCommnet DEL_ALL_HOST_COMMENTS
@@ -204,7 +204,7 @@ func (a *Api) HandleDeleteAllHostCommnet(w http.ResponseWriter, r *http.Request)
 	}
 
 	command := fmt.Sprintf("%s;%s", "DEL_ALL_HOST_COMMENTS", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDeleteAllServiceComment DEL_ALL_SVC_COMMENTS
@@ -225,7 +225,7 @@ func (a *Api) HandleDeleteAllServiceComment(w http.ResponseWriter, r *http.Reque
 	}
 
 	command := fmt.Sprintf("%s;%s", "DEL_ALL_SVC_COMMENTS", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDeleteHostComment DEL_HOST_COMMENT
@@ -246,7 +246,7 @@ func (a *Api) HandleDeleteHostComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	command := fmt.Sprintf("%s;%s", "DEL_HOST_COMMENT", data.CommentID)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDeleteServiceComment DEL_SVC_COMMENT
@@ -267,7 +267,7 @@ func (a *Api) HandleDeleteServiceComment(w http.ResponseWriter, r *http.Request)
 	}
 
 	command := fmt.Sprintf("%s;%s", "DEL_SVC_COMMENT", data.CommentID)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableAllNotificationBeyondHost DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST
@@ -288,7 +288,7 @@ func (a *Api) HandleDisableAllNotificationBeyondHost(w http.ResponseWriter, r *h
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleEnableAllNotificationBeyondHost ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST
@@ -309,7 +309,7 @@ func (a *Api) HandleEnableAllNotificationBeyondHost(w http.ResponseWriter, r *ht
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableHostgroupHostChecks DISABLE_HOSTGROUP_HOST_CHECKS
@@ -330,7 +330,7 @@ func (a *Api) HandleDisableHostgroupHostChecks(w http.ResponseWriter, r *http.Re
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOSTGROUP_HOST_CHECKS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleEnableHostgroupHostChecks ENABLE_HOSTGROUP_HOST_CHECKS
@@ -351,7 +351,7 @@ func (a *Api) HandleEnableHostgroupHostChecks(w http.ResponseWriter, r *http.Req
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOSTGROUP_HOST_CHECKS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableHostgroupHostNotification DISABLE_HOSTGROUP_HOST_NOTIFICATIONS
@@ -372,7 +372,7 @@ func (a *Api) HandleDisableHostgroupHostNotification(w http.ResponseWriter, r *h
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOSTGROUP_HOST_NOTIFICATIONS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleEnableHostgroupHostNotification ENABLE_HOSTGROUP_HOST_NOTIFICATIONS;<hostgroup_name>
@@ -393,7 +393,7 @@ func (a *Api) HandleEnableHostgroupHostNotification(w http.ResponseWriter, r *ht
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOSTGROUP_HOST_NOTIFICATIONS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableHostgroupServiceChecks DISABLE_HOSTGROUP_SVC_CHECKS
@@ -414,7 +414,7 @@ func (a *Api) HandleDisableHostgroupServiceChecks(w http.ResponseWriter, r *http
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOSTGROUP_SVC_CHECKS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleEnableHostgroupServiceChecks ENABLE_HOSTGROUP_SVC_CHECKS
@@ -435,7 +435,7 @@ func (a *Api) HandleEnableHostgroupServiceChecks(w http.ResponseWriter, r *http.
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOSTGROUP_SVC_CHECKS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableHostgroupServiceNotifications DISABLE_HOSTGROUP_SVC_NOTIFICATIONS
@@ -456,7 +456,7 @@ func (a *Api) HandleDisableHostgroupServiceNotifications(w http.ResponseWriter, 
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOSTGROUP_SVC_NOTIFICATIONS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleEnableHostgroupServiceNotifications ENABLE_HOSTGROUP_SVC_NOTIFICATIONS
@@ -477,7 +477,7 @@ func (a *Api) HandleEnableHostgroupServiceNotifications(w http.ResponseWriter, r
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOSTGROUP_SVC_NOTIFICATIONS", data.Hostgroup)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // HandleDisableHostandChildNotifications DISABLE_HOST_AND_CHILD_NOTIFICATIONS
@@ -498,7 +498,7 @@ func (a *Api) HandleDisableHostandChildNotifications(w http.ResponseWriter, r *h
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOST_AND_CHILD_NOTIFICATIONS", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // ENABLE_HOST_AND_CHILD_NOTIFICATIONS
@@ -519,7 +519,7 @@ func (a *Api) HandleEnableHostandChildNotifications(w http.ResponseWriter, r *ht
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOST_AND_CHILD_NOTIFICATIONS", data.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // DISABLE_HOST_CHECK
@@ -534,7 +534,7 @@ func (a *Api) HandleDisableHostCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOST_CHECK", host.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // ENABLE_HOST_CHECK
@@ -549,7 +549,7 @@ func (a *Api) HandleEnableHostCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOST_CHECK", host.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // DISABLE_HOST_NOTIFICATIONS
@@ -564,7 +564,7 @@ func (a *Api) HandleDisableHostNotifications(w http.ResponseWriter, r *http.Requ
 	}
 
 	command := fmt.Sprintf("%s;%s", "DISABLE_HOST_NOTIFICATIONS", host.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // ENABLE_HOST_NOTIFICATIONS
@@ -579,21 +579,21 @@ func (a *Api) HandleEnableHostNotifications(w http.ResponseWriter, r *http.Reque
 	}
 
 	command := fmt.Sprintf("%s;%s", "ENABLE_HOST_NOTIFICATIONS", host.Hostname)
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // DISABLE_NOTIFICATIONS
 // POST: /disable_notifications
 func (a *Api) HandleDisableNotifications(w http.ResponseWriter, r *http.Request) {
 	command := "DISABLE_NOTIFICATIONS"
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // ENABLE_NOTIFICATIONS
 // POST: /enable_notifications
 func (a *Api) HandleEnableNotifications(w http.ResponseWriter, r *http.Request) {
 	command := "ENABLE_NOTIFICATIONS"
-	WriteCommandToFile(w, command)
+	a.WriteCommandToFile(w, command)
 }
 
 // SCHEDULE_FORCED_HOST_CHECK
@@ -621,8 +621,8 @@ func (a *Api) HandleScheduleHostCheck(w http.ResponseWriter, r *http.Request) {
 func (a *Api) HandleScheduleHostDowntime(w http.ResponseWriter, r *http.Request) {
 }
 
-func WriteCommandToFile(w http.ResponseWriter, command string) {
-	if err := WriteCommand(command); err != nil {
+func (a *Api) WriteCommandToFile(w http.ResponseWriter, command string) {
+	if err := a.WriteCommand(command); err != nil {
 		http.Error(w, "Could not execute command", 500)
 		return
 	}

--- a/api/command_handlers.go
+++ b/api/command_handlers.go
@@ -11,7 +11,7 @@ import (
 // HandleAcknowledgeHostProblem ACKNOWLEDGE_HOST_PROBLEM
 // POST: /acknowledge_host_problem/<host>
 //       {sticky:bool, notify:bool, persistent:bool, author:string, comment:string}
-func HandleAcknowledgeHostProblem(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleAcknowledgeHostProblem(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname   string
@@ -56,7 +56,7 @@ func HandleAcknowledgeHostProblem(w http.ResponseWriter, r *http.Request) {
 // HandleAcknowledgeServiceProblem ACKNOWLEDGE_SVC_PROBLEM
 // POST: /acknowledge_service_problem
 //       {sticky:bool, notify:bool, persistent:bool, author:string, comment:string}
-func HandleAcknowledgeServiceProblem(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleAcknowledgeServiceProblem(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname           string
@@ -102,7 +102,7 @@ func HandleAcknowledgeServiceProblem(w http.ResponseWriter, r *http.Request) {
 // HandleAddHostComment ADD_HOST_COMMENT
 // POST: /add_host_comment/<host>
 //       {persistent:bool, author:string, comment:string}
-func HandleAddHostComment(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleAddHostComment(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname   string
@@ -143,7 +143,7 @@ func HandleAddHostComment(w http.ResponseWriter, r *http.Request) {
 // HandleAddServiceComment ADD_SVC_COMMENT
 // POST: /add_svc_comment/<host>/<service>
 //       {persistent:bool, author:string, comment:string}
-func HandleAddServiceComment(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleAddServiceComment(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname   string
@@ -187,7 +187,7 @@ func HandleAddServiceComment(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDeleteAllHostCommnet DEL_ALL_HOST_COMMENTS
-func HandleDeleteAllHostCommnet(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDeleteAllHostCommnet(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -208,7 +208,7 @@ func HandleDeleteAllHostCommnet(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDeleteAllServiceComment DEL_ALL_SVC_COMMENTS
-func HandleDeleteAllServiceComment(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDeleteAllServiceComment(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -229,7 +229,7 @@ func HandleDeleteAllServiceComment(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDeleteHostComment DEL_HOST_COMMENT
-func HandleDeleteHostComment(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDeleteHostComment(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		CommentID string
@@ -250,7 +250,7 @@ func HandleDeleteHostComment(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDeleteServiceComment DEL_SVC_COMMENT
-func HandleDeleteServiceComment(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDeleteServiceComment(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		CommentID string
@@ -271,7 +271,7 @@ func HandleDeleteServiceComment(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDisableAllNotificationBeyondHost DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST
-func HandleDisableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -292,7 +292,7 @@ func HandleDisableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Reque
 }
 
 // HandleEnableAllNotificationBeyondHost ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST
-func HandleEnableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -313,7 +313,7 @@ func HandleEnableAllNotificationBeyondHost(w http.ResponseWriter, r *http.Reques
 }
 
 // HandleDisableHostgroupHostChecks DISABLE_HOSTGROUP_HOST_CHECKS
-func HandleDisableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -334,7 +334,7 @@ func HandleDisableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleEnableHostgroupHostChecks ENABLE_HOSTGROUP_HOST_CHECKS
-func HandleEnableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -355,7 +355,7 @@ func HandleEnableHostgroupHostChecks(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDisableHostgroupHostNotification DISABLE_HOSTGROUP_HOST_NOTIFICATIONS
-func HandleDisableHostgroupHostNotification(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostgroupHostNotification(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -376,7 +376,7 @@ func HandleDisableHostgroupHostNotification(w http.ResponseWriter, r *http.Reque
 }
 
 // HandleEnableHostgroupHostNotification ENABLE_HOSTGROUP_HOST_NOTIFICATIONS;<hostgroup_name>
-func HandleEnableHostgroupHostNotification(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostgroupHostNotification(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -397,7 +397,7 @@ func HandleEnableHostgroupHostNotification(w http.ResponseWriter, r *http.Reques
 }
 
 // HandleDisableHostgroupServiceChecks DISABLE_HOSTGROUP_SVC_CHECKS
-func HandleDisableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -418,7 +418,7 @@ func HandleDisableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request)
 }
 
 // HandleEnableHostgroupServiceChecks ENABLE_HOSTGROUP_SVC_CHECKS
-func HandleEnableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -439,7 +439,7 @@ func HandleEnableHostgroupServiceChecks(w http.ResponseWriter, r *http.Request) 
 }
 
 // HandleDisableHostgroupServiceNotifications DISABLE_HOSTGROUP_SVC_NOTIFICATIONS
-func HandleDisableHostgroupServiceNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostgroupServiceNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -460,7 +460,7 @@ func HandleDisableHostgroupServiceNotifications(w http.ResponseWriter, r *http.R
 }
 
 // HandleEnableHostgroupServiceNotifications ENABLE_HOSTGROUP_SVC_NOTIFICATIONS
-func HandleEnableHostgroupServiceNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostgroupServiceNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostgroup string
@@ -481,7 +481,7 @@ func HandleEnableHostgroupServiceNotifications(w http.ResponseWriter, r *http.Re
 }
 
 // HandleDisableHostandChildNotifications DISABLE_HOST_AND_CHILD_NOTIFICATIONS
-func HandleDisableHostandChildNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostandChildNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -502,7 +502,7 @@ func HandleDisableHostandChildNotifications(w http.ResponseWriter, r *http.Reque
 }
 
 // ENABLE_HOST_AND_CHILD_NOTIFICATIONS
-func HandleEnableHostandChildNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostandChildNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data struct {
 		Hostname string
@@ -524,7 +524,7 @@ func HandleEnableHostandChildNotifications(w http.ResponseWriter, r *http.Reques
 
 // DISABLE_HOST_CHECK
 // POST: /disable_host_check
-func HandleDisableHostCheck(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostCheck(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var host struct{ Hostname string }
 	err := decoder.Decode(&host)
@@ -539,7 +539,7 @@ func HandleDisableHostCheck(w http.ResponseWriter, r *http.Request) {
 
 // ENABLE_HOST_CHECK
 // POST: /enable_host_check
-func HandleEnableHostCheck(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostCheck(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var host struct{ Hostname string }
 	err := decoder.Decode(&host)
@@ -554,7 +554,7 @@ func HandleEnableHostCheck(w http.ResponseWriter, r *http.Request) {
 
 // DISABLE_HOST_NOTIFICATIONS
 // POST: /disable_host_notifications
-func HandleDisableHostNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableHostNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var host struct{ Hostname string }
 	err := decoder.Decode(&host)
@@ -569,7 +569,7 @@ func HandleDisableHostNotifications(w http.ResponseWriter, r *http.Request) {
 
 // ENABLE_HOST_NOTIFICATIONS
 // POST: /enable_host_notifications
-func HandleEnableHostNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableHostNotifications(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var host struct{ Hostname string }
 	err := decoder.Decode(&host)
@@ -584,41 +584,41 @@ func HandleEnableHostNotifications(w http.ResponseWriter, r *http.Request) {
 
 // DISABLE_NOTIFICATIONS
 // POST: /disable_notifications
-func HandleDisableNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleDisableNotifications(w http.ResponseWriter, r *http.Request) {
 	command := "DISABLE_NOTIFICATIONS"
 	WriteCommandToFile(w, command)
 }
 
 // ENABLE_NOTIFICATIONS
 // POST: /enable_notifications
-func HandleEnableNotifications(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleEnableNotifications(w http.ResponseWriter, r *http.Request) {
 	command := "ENABLE_NOTIFICATIONS"
 	WriteCommandToFile(w, command)
 }
 
 // SCHEDULE_FORCED_HOST_CHECK
 // SCHEDULE_FORCED_HOST_CHECK;<host_name>;<check_time>
-func HandleScheduleForcedHostCheck(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleScheduleForcedHostCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // SCHEDULE_FORCED_HOST_SVC_CHECKS
 // SCHEDULE_FORCED_HOST_SVC_CHECKS;<host_name>;<check_time>
-func HandleScheduleForcedHostServiceChecks(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleScheduleForcedHostServiceChecks(w http.ResponseWriter, r *http.Request) {
 }
 
 // SCHEDULE_FORCED_SVC_CHECK
 // SCHEDULE_FORCED_SVC_CHECK;<host_name>;<service_description>;<check_time>
-func HandleScheduleForcedServiceCheck(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleScheduleForcedServiceCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // SCHEDULE_HOST_CHECK
 // SCHEDULE_HOST_CHECK;<host_name>;<check_time>
-func HandleScheduleHostCheck(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleScheduleHostCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // SCHEDULE_HOST_DOWNTIME
 // SCHEDULE_HOST_DOWNTIME;<host_name>;<start_time>;<end_time>;<fixed>;<trigger_id>;<duration>;<author>;<comment>
-func HandleScheduleHostDowntime(w http.ResponseWriter, r *http.Request) {
+func (a *Api) HandleScheduleHostDowntime(w http.ResponseWriter, r *http.Request) {
 }
 
 func WriteCommandToFile(w http.ResponseWriter, command string) {

--- a/api/objects.go
+++ b/api/objects.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type ContactStatus struct {
+	ContactName                 string `json:"contact_name"`
+	HostNotificationPeriod      string `json:"host_notification_period"`
+	HostNotificationsEnabled    string `json:"host_notifications_enabled"`
+	LastHostNotification        string `json:"last_host_notification"`
+	LastServiceNotification     string `json:"last_service_notification"`
+	ModifiedAttributes          string `json:"modified_attributes"`
+	ModifiedHostAttributes      string `json:"modified_host_attributes"`
+	ModifiedServiceAttributes   string `json:"modified_service_attributes"`
+	ServiceNotificationPeriod   string `json:"service_notification_period"`
+	ServiceNotificationsEnabled string `json:"service_notifications_enabled"`
+}
+type HostStatus struct {
+	AcknowledgementType        string `json:"acknowledgement_type"`
+	ActiveChecksEnabled        string `json:"active_checks_enabled"`
+	CheckCommand               string `json:"check_command"`
+	CheckExecutionTime         string `json:"check_execution_time"`
+	CheckInterval              string `json:"check_interval"`
+	CheckLatency               string `json:"check_latency"`
+	CheckOptions               string `json:"check_options"`
+	CheckPeriod                string `json:"check_period"`
+	CheckType                  string `json:"check_type"`
+	CurrentAttempt             string `json:"current_attempt"`
+	CurrentEventId             string `json:"current_event_id"`
+	CurrentNotificationId      string `json:"current_notification_id"`
+	CurrentNotificationNumber  string `json:"current_notification_number"`
+	CurrentProblemId           string `json:"current_problem_id"`
+	CurrentState               string `json:"current_state"`
+	EventHandler               string `json:"event_handler"`
+	EventHandlerEnabled        string `json:"event_handler_enabled"`
+	FlapDetectionEnabled       string `json:"flap_detection_enabled"`
+	HasBeenChecked             string `json:"has_been_checked"`
+	HostName                   string `json:"host_name"`
+	IsFlapping                 string `json:"is_flapping"`
+	LastCheck                  string `json:"last_check"`
+	LastEventId                string `json:"last_event_id"`
+	LastHardState              string `json:"last_hard_state"`
+	LastHardStateChange        string `json:"last_hard_state_change"`
+	LastNotification           string `json:"last_notification"`
+	LastProblemId              string `json:"last_problem_id"`
+	LastStateChange            string `json:"last_state_change"`
+	LastTimeDown               string `json:"last_time_down"`
+	LastTimeUnreachable        string `json:"last_time_unreachable"`
+	LastTimeUp                 string `json:"last_time_up"`
+	LastUpdate                 string `json:"last_update"`
+	LongPluginOutput           string `json:"long_plugin_output"`
+	MaxAttempts                string `json:"max_attempts"`
+	ModifiedAttributes         string `json:"modified_attributes"`
+	NextCheck                  string `json:"next_check"`
+	NextNotification           string `json:"next_notification"`
+	NoMoreNotifications        string `json:"no_more_notifications"`
+	NotificationPeriod         string `json:"notification_period"`
+	NotificationsEnabled       string `json:"notifications_enabled"`
+	Obsess                     string `json:"obsess"`
+	PassiveChecksEnabled       string `json:"passive_checks_enabled"`
+	PercentStateChange         string `json:"percent_state_change"`
+	PerformanceData            string `json:"performance_data"`
+	PluginOutput               string `json:"plugin_output"`
+	ProblemHasBeenAcknowledged string `json:"problem_has_been_acknowledged"`
+	ProcessPerformanceData     string `json:"process_performance_data"`
+	RetryInterval              string `json:"retry_interval"`
+	ScheduledDowntimeDepth     string `json:"scheduled_downtime_depth"`
+	ShouldBeScheduled          string `json:"should_be_scheduled"`
+	StateType                  string `json:"state_type"`
+}
+type ProgramStatus struct {
+	ActiveHostChecksEnabled          string `json:"active_host_checks_enabled"`
+	ActiveOndemandHostCheckStats     string `json:"active_ondemand_host_check_stats"`
+	ActiveOndemandServiceCheckStats  string `json:"active_ondemand_service_check_stats"`
+	ActiveScheduledHostCheckStats    string `json:"active_scheduled_host_check_stats"`
+	ActiveScheduledServiceCheckStats string `json:"active_scheduled_service_check_stats"`
+	ActiveServiceChecksEnabled       string `json:"active_service_checks_enabled"`
+	CachedHostCheckStats             string `json:"cached_host_check_stats"`
+	CachedServiceCheckStats          string `json:"cached_service_check_stats"`
+	CheckHostFreshness               string `json:"check_host_freshness"`
+	CheckServiceFreshness            string `json:"check_service_freshness"`
+	DaemonMode                       string `json:"daemon_mode"`
+	EnableEventHandlers              string `json:"enable_event_handlers"`
+	EnableFlapDetection              string `json:"enable_flap_detection"`
+	EnableNotifications              string `json:"enable_notifications"`
+	ExternalCommandStats             string `json:"external_command_stats"`
+	GlobalHostEventHandler           string `json:"global_host_event_handler"`
+	GlobalServiceEventHandler        string `json:"global_service_event_handler"`
+	LastLogRotation                  string `json:"last_log_rotation"`
+	ModifiedHostAttributes           string `json:"modified_host_attributes"`
+	ModifiedServiceAttributes        string `json:"modified_service_attributes"`
+	NagiosPid                        string `json:"nagios_pid"`
+	NextCommentId                    string `json:"next_comment_id"`
+	NextDowntimeId                   string `json:"next_downtime_id"`
+	NextEventId                      string `json:"next_event_id"`
+	NextNotificationId               string `json:"next_notification_id"`
+	NextProblemId                    string `json:"next_problem_id"`
+	ObsessOverHosts                  string `json:"obsess_over_hosts"`
+	ObsessOverServices               string `json:"obsess_over_services"`
+	ParallelHostCheckStats           string `json:"parallel_host_check_stats"`
+	PassiveHostCheckStats            string `json:"passive_host_check_stats"`
+	PassiveHostChecksEnabled         string `json:"passive_host_checks_enabled"`
+	PassiveServiceCheckStats         string `json:"passive_service_check_stats"`
+	PassiveServiceChecksEnabled      string `json:"passive_service_checks_enabled"`
+	ProcessPerformanceData           string `json:"process_performance_data"`
+	ProgramStart                     string `json:"program_start"`
+	SerialHostCheckStats             string `json:"serial_host_check_stats"`
+}
+type ServiceStatus struct {
+	AcknowledgementType        string `json:"acknowledgement_type"`
+	ActiveChecksEnabled        string `json:"active_checks_enabled"`
+	CheckCommand               string `json:"check_command"`
+	CheckExecutionTime         string `json:"check_execution_time"`
+	CheckInterval              string `json:"check_interval"`
+	CheckLatency               string `json:"check_latency"`
+	CheckOptions               string `json:"check_options"`
+	CheckPeriod                string `json:"check_period"`
+	CheckType                  string `json:"check_type"`
+	CurrentAttempt             string `json:"current_attempt"`
+	CurrentEventId             string `json:"current_event_id"`
+	CurrentNotificationId      string `json:"current_notification_id"`
+	CurrentNotificationNumber  string `json:"current_notification_number"`
+	CurrentProblemId           string `json:"current_problem_id"`
+	CurrentState               string `json:"current_state"`
+	EventHandler               string `json:"event_handler"`
+	EventHandlerEnabled        string `json:"event_handler_enabled"`
+	FlapDetectionEnabled       string `json:"flap_detection_enabled"`
+	HasBeenChecked             string `json:"has_been_checked"`
+	HostName                   string `json:"host_name"`
+	IsFlapping                 string `json:"is_flapping"`
+	LastCheck                  string `json:"last_check"`
+	LastEventId                string `json:"last_event_id"`
+	LastHardState              string `json:"last_hard_state"`
+	LastHardStateChange        string `json:"last_hard_state_change"`
+	LastNotification           string `json:"last_notification"`
+	LastProblemId              string `json:"last_problem_id"`
+	LastStateChange            string `json:"last_state_change"`
+	LastTimeCritical           string `json:"last_time_critical"`
+	LastTimeOk                 string `json:"last_time_ok"`
+	LastTimeUnknown            string `json:"last_time_unknown"`
+	LastTimeWarning            string `json:"last_time_warning"`
+	LastUpdate                 string `json:"last_update"`
+	LongPluginOutput           string `json:"long_plugin_output"`
+	MaxAttempts                string `json:"max_attempts"`
+	ModifiedAttributes         string `json:"modified_attributes"`
+	NextCheck                  string `json:"next_check"`
+	NextNotification           string `json:"next_notification"`
+	NoMoreNotifications        string `json:"no_more_notifications"`
+	NotificationPeriod         string `json:"notification_period"`
+	NotificationsEnabled       string `json:"notifications_enabled"`
+	Obsess                     string `json:"obsess"`
+	PassiveChecksEnabled       string `json:"passive_checks_enabled"`
+	PercentStateChange         string `json:"percent_state_change"`
+	PerformanceData            string `json:"performance_data"`
+	PluginOutput               string `json:"plugin_output"`
+	ProblemHasBeenAcknowledged string `json:"problem_has_been_acknowledged"`
+	ProcessPerformanceData     string `json:"process_performance_data"`
+	RetryInterval              string `json:"retry_interval"`
+	ScheduledDowntimeDepth     string `json:"scheduled_downtime_depth"`
+	ServiceDescription         string `json:"service_description"`
+	ShouldBeScheduled          string `json:"should_be_scheduled"`
+	StateType                  string `json:"state_type"`
+}
+
+func (o *ContactStatus) setField(key, value string) error {
+	return setField(o, key, value)
+}
+
+func (o *HostStatus) setField(key, value string) error {
+	return setField(o, key, value)
+}
+
+func (o *ProgramStatus) setField(key, value string) error {
+	return setField(o, key, value)
+}
+
+func (o *ServiceStatus) setField(key, value string) error {
+	return setField(o, key, value)
+}
+
+// setField sets a field in a struct based on the JSON tag associated with the struct
+func setField(obj interface{}, name string, value interface{}) error {
+	val := reflect.ValueOf(obj).Elem()
+
+	for i := 0; i < val.NumField(); i++ {
+		elem := val.Type().Field(i)
+		tag := elem.Tag
+		field := val.Field(i)
+
+		js := tag.Get("json")
+		if js == "" {
+			continue
+		}
+
+		comma := strings.Index(js, ",")
+		if comma != -1 {
+			js = js[0:comma]
+		}
+
+		if js == name {
+			if !field.CanSet() {
+				return fmt.Errorf("Cannot set %s field value", name)
+			}
+
+			valValue := reflect.ValueOf(value)
+			if field.Type() != valValue.Type() {
+				return errors.New("Provided value type didn't match obj field type")
+			}
+
+			field.Set(valValue)
+			return nil
+		}
+	}
+	return fmt.Errorf("No such field: %s in obj", name)
+}

--- a/api/objects_test.go
+++ b/api/objects_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/cheekybits/is"
+)
+
+type testData struct {
+	Field string `json:"field_foo,omitempty"`
+}
+
+func (t *testData) setField(k, v string) error {
+	return setField(t, k, v)
+}
+
+func TestSetField(t *testing.T) {
+	is := is.New(t)
+
+	o := &testData{}
+	err := o.setField("field_foo", "123")
+	is.NoErr(err)
+	is.Equal("123", o.Field)
+}
+
+func TestParseBlock(t *testing.T) {
+	is := is.New(t)
+
+	dat, err := ioutil.ReadFile("testdata/contact_status.dat")
+	is.NoErr(err)
+
+	a := strings.SplitAfterN(string(dat), "}", -1)
+	is.Equal(2, len(a))
+
+	lines := strings.Split(a[0], "\n")
+
+	c := &ContactStatus{}
+	parseBlock(c, "contactstatus", lines)
+
+	// Sample a handful of fields
+	is.Equal(c.ContactName, "jason")
+	is.Equal(c.ModifiedAttributes, "0")
+	is.Equal(c.ModifiedHostAttributes, "0")
+	is.Equal(c.LastHostNotification, "1481756484")
+	is.Equal(c.ServiceNotificationPeriod, "24x7")
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"github.com/sulochan/go-nagios-api/auth"
+
+	"github.com/justinas/alice"
+)
+
+func (s *Api) buildRoutes() {
+	chain := alice.New()
+
+	s.router.Handle("/contacts", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetContacts)).Methods("GET")
+
+	s.router.Handle("/hosts", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetConfiguredHosts)).Methods("GET")
+	s.router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetHost)).Methods("GET")
+	s.router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}/services", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetServicesForHost)).Methods("GET")
+	s.router.Handle("/hoststatus", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetAllHostStatus)).Methods("GET")
+	s.router.Handle("/hoststatus/{hostname:[a-z,A-Z,0-9,_.-]+}", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetHostStatusForHost)).Methods("GET")
+	s.router.Handle("/hostgroups", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetHostGroups)).Methods("GET")
+
+	s.router.Handle("/services", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetConfiguredServices)).Methods("GET")
+	s.router.Handle("/servicestatus", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetServiceStatus)).Methods("GET")
+	s.router.Handle("/servicestatus/{service:[a-z,A-Z,0-9,_.-]+}", chain.Append(auth.AuthHandler).ThenFunc(s.HandleGetServiceStatusForService)).Methods("GET")
+
+	// Nagios External Command Handlers
+	s.router.Handle("/disable_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableNotifications)).Methods("POST")
+	s.router.Handle("/enable_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableNotifications)).Methods("POST")
+	s.router.Handle("/disable_host_check", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostCheck)).Methods("POST")
+	s.router.Handle("/enable_host_check", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostCheck)).Methods("POST")
+	s.router.Handle("/disable_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostNotifications)).Methods("POST")
+	s.router.Handle("/enable_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostNotifications)).Methods("POST")
+	s.router.Handle("/acknowledge_host_problem", chain.Append(auth.AuthHandler).ThenFunc(s.HandleAcknowledgeHostProblem)).Methods("POST")
+	s.router.Handle("/acknowledge_service_problem", chain.Append(auth.AuthHandler).ThenFunc(s.HandleAcknowledgeServiceProblem)).Methods("POST")
+	s.router.Handle("/add_host_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleAddHostComment)).Methods("POST")
+	s.router.Handle("/add_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleAddServiceComment)).Methods("POST")
+	s.router.Handle("/del_all_host_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDeleteAllHostCommnet)).Methods("POST")
+	s.router.Handle("/del_all_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDeleteAllServiceComment)).Methods("POST")
+	s.router.Handle("/del_host_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDeleteHostComment)).Methods("POST")
+	s.router.Handle("/del_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDeleteServiceComment)).Methods("POST")
+	s.router.Handle("/disable_all_notification_beyond_host", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableAllNotificationBeyondHost)).Methods("POST")
+	s.router.Handle("/enable_all_notification_beyond_host", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableAllNotificationBeyondHost)).Methods("POST")
+	s.router.Handle("/disable_hostgroup_host_checks", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostgroupHostChecks)).Methods("POST")
+	s.router.Handle("/enable_hostgroup_host_checks", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostgroupHostChecks)).Methods("POST")
+	s.router.Handle("/disable_hostgroup_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostgroupHostNotification)).Methods("POST")
+	s.router.Handle("/enable_hostgroup_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostgroupHostNotification)).Methods("POST")
+	s.router.Handle("/disable_hostgroup_svc_checks", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostgroupServiceChecks)).Methods("POST")
+	s.router.Handle("/enable_hostgroup_svc_checks", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostgroupServiceChecks)).Methods("POST")
+	s.router.Handle("/disable_hostgroup_svc_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostgroupServiceNotifications)).Methods("POST")
+	s.router.Handle("/enable_hostgroup_svc_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostgroupServiceNotifications)).Methods("POST")
+	s.router.Handle("/disable_host_and_child_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleDisableHostandChildNotifications)).Methods("POST")
+	s.router.Handle("/enable_host_and_child_notifications", chain.Append(auth.AuthHandler).ThenFunc(s.HandleEnableHostandChildNotifications)).Methods("POST")
+}

--- a/api/testdata/contact_status.dat
+++ b/api/testdata/contact_status.dat
@@ -1,0 +1,12 @@
+contactstatus {
+    contact_name=jason
+    modified_attributes=0
+    modified_host_attributes=0
+    modified_service_attributes=0
+    host_notification_period=24x7
+    service_notification_period=24x7
+    last_host_notification=1481756484
+    last_service_notification=1484082873
+    host_notifications_enabled=1
+    service_notifications_enabled=1
+    }

--- a/api/write_nagios_command.go
+++ b/api/write_nagios_command.go
@@ -6,26 +6,22 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/sulochan/go-nagios-api/config"
 )
 
-func WriteCommand(command string) error {
-	conf := config.GetConfig()
-	timeNow := time.Now()
-	s := fmt.Sprintf("[%d]", timeNow.Unix())
-	commandToWrite := fmt.Sprintf("%s %s%s", s, command, "\n")
+func (a *Api) WriteCommand(command string) error {
+	commandToWrite := fmt.Sprintf("[%d] %s\n", time.Now().Unix(), command)
 
-	f, err := os.OpenFile(conf.CommandFile, os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(a.fileCommand, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
+	defer f.Close()
 
 	if _, err = f.WriteString(commandToWrite); err != nil {
 		log.Error(err)
 		return err
 	}
 
-	defer f.Close()
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"io/ioutil"
-	"sync"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -14,12 +13,10 @@ type Config struct {
 	ObjectCacheFile string
 	StatusFile      string
 	CommandFile     string
-	Logfile         string
 }
 
 var (
 	config          *Config
-	configLock      = new(sync.RWMutex)
 	configfile      *string
 	objectCacheFile *string
 	statusFile      *string
@@ -56,13 +53,9 @@ func loadConfigFile() {
 	if err = json.Unmarshal(file, temp); err != nil {
 		log.Fatal("parse config: ", err)
 	}
-	configLock.Lock()
 	config = temp
-	configLock.Unlock()
 }
 
 func GetConfig() *Config {
-	configLock.RLock()
-	defer configLock.RUnlock()
 	return config
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	Port            string
+	Addr            string
 	ObjectCacheFile string
 	StatusFile      string
 	CommandFile     string
@@ -24,7 +24,7 @@ var (
 	objectCacheFile *string
 	statusFile      *string
 	commandFile     *string
-	port            *string
+	addr            *string
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 	objectCacheFile = flag.String("cachefile", "/usr/local/nagios/var/objects.cache", "Nagios object.cache file location")
 	statusFile = flag.String("statusfile", "/usr/local/nagios/var/status.dat", "Nagios status.dat file location")
 	commandFile = flag.String("commandfile", "/usr/local/nagios/var/nagios.cmd", "Nagios command file location")
-	port = flag.String("port", "9090", "Port to run server on")
+	addr = flag.String("addr", ":9090", "The interface and port to run server on")
 	flag.Parse()
 
 	if *configfile != "" {
@@ -43,7 +43,7 @@ func init() {
 }
 
 func loadConfigFlags() {
-	config = &Config{Port: *port, ObjectCacheFile: *objectCacheFile, StatusFile: *statusFile, CommandFile: *commandFile}
+	config = &Config{Addr: *addr, ObjectCacheFile: *objectCacheFile, StatusFile: *statusFile, CommandFile: *commandFile}
 }
 
 func loadConfigFile() {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	conf := config.GetConfig()
 	chain := alice.New()
 	router := mux.NewRouter()
+	api.Initialize()
 	http.Handle("/", router)
 	router.Handle("/contacts", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetContacts)).Methods("GET")
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	conf := config.GetConfig()
-	api := api.NewApi(conf.Addr)
+	api := api.NewApi(conf.Addr, conf.ObjectCacheFile, conf.CommandFile, conf.StatusFile)
 
 	err := api.Run()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	router.Handle("/hosts", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetConfiguredHosts)).Methods("GET")
 	router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHost)).Methods("GET")
+	router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}/services", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetServicesForHost)).Methods("GET")
 	router.Handle("/hoststatus", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetAllHostStatus)).Methods("GET")
 	router.Handle("/hoststatus/{hostname:[a-z,A-Z,0-9,_.-]+}", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHostStatusForHost)).Methods("GET")
 	router.Handle("/hostgroups", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHostGroups)).Methods("GET")

--- a/main.go
+++ b/main.go
@@ -1,67 +1,18 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/sulochan/go-nagios-api/api"
-	"github.com/sulochan/go-nagios-api/auth"
 	"github.com/sulochan/go-nagios-api/config"
-
-	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 )
 
 func main() {
 	conf := config.GetConfig()
-	chain := alice.New()
-	router := mux.NewRouter()
-	api.Initialize()
-	http.Handle("/", router)
-	router.Handle("/contacts", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetContacts)).Methods("GET")
+	api := api.NewApi(conf.Addr)
 
-	router.Handle("/hosts", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetConfiguredHosts)).Methods("GET")
-	router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHost)).Methods("GET")
-	router.Handle("/host/{hostname:[a-z,A-Z,0-9, _.-]+}/services", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetServicesForHost)).Methods("GET")
-	router.Handle("/hoststatus", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetAllHostStatus)).Methods("GET")
-	router.Handle("/hoststatus/{hostname:[a-z,A-Z,0-9,_.-]+}", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHostStatusForHost)).Methods("GET")
-	router.Handle("/hostgroups", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetHostGroups)).Methods("GET")
-
-	router.Handle("/services", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetConfiguredServices)).Methods("GET")
-	router.Handle("/servicestatus", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetServiceStatus)).Methods("GET")
-	router.Handle("/servicestatus/{service:[a-z,A-Z,0-9,_.-]+}", chain.Append(auth.AuthHandler).ThenFunc(api.HandleGetServiceStatusForService)).Methods("GET")
-
-	// Nagios External Command Handlers
-	router.Handle("/disable_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableNotifications)).Methods("POST")
-	router.Handle("/enable_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableNotifications)).Methods("POST")
-	router.Handle("/disable_host_check", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostCheck)).Methods("POST")
-	router.Handle("/enable_host_check", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostCheck)).Methods("POST")
-	router.Handle("/disable_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostNotifications)).Methods("POST")
-	router.Handle("/enable_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostNotifications)).Methods("POST")
-	router.Handle("/acknowledge_host_problem", chain.Append(auth.AuthHandler).ThenFunc(api.HandleAcknowledgeHostProblem)).Methods("POST")
-	router.Handle("/acknowledge_service_problem", chain.Append(auth.AuthHandler).ThenFunc(api.HandleAcknowledgeServiceProblem)).Methods("POST")
-	router.Handle("/add_host_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleAddHostComment)).Methods("POST")
-	router.Handle("/add_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleAddServiceComment)).Methods("POST")
-	router.Handle("/del_all_host_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDeleteAllHostCommnet)).Methods("POST")
-	router.Handle("/del_all_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDeleteAllServiceComment)).Methods("POST")
-	router.Handle("/del_host_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDeleteHostComment)).Methods("POST")
-	router.Handle("/del_svc_comment", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDeleteServiceComment)).Methods("POST")
-	router.Handle("/disable_all_notification_beyond_host", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableAllNotificationBeyondHost)).Methods("POST")
-	router.Handle("/enable_all_notification_beyond_host", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableAllNotificationBeyondHost)).Methods("POST")
-	router.Handle("/disable_hostgroup_host_checks", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostgroupHostChecks)).Methods("POST")
-	router.Handle("/enable_hostgroup_host_checks", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostgroupHostChecks)).Methods("POST")
-	router.Handle("/disable_hostgroup_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostgroupHostNotification)).Methods("POST")
-	router.Handle("/enable_hostgroup_host_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostgroupHostNotification)).Methods("POST")
-	router.Handle("/disable_hostgroup_svc_checks", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostgroupServiceChecks)).Methods("POST")
-	router.Handle("/enable_hostgroup_svc_checks", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostgroupServiceChecks)).Methods("POST")
-	router.Handle("/disable_hostgroup_svc_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostgroupServiceNotifications)).Methods("POST")
-	router.Handle("/enable_hostgroup_svc_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostgroupServiceNotifications)).Methods("POST")
-	router.Handle("/disable_host_and_child_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleDisableHostandChildNotifications)).Methods("POST")
-	router.Handle("/enable_host_and_child_notifications", chain.Append(auth.AuthHandler).ThenFunc(api.HandleEnableHostandChildNotifications)).Methods("POST")
-
-	if err := http.ListenAndServe(fmt.Sprintf(":%s", conf.Port), nil); err != nil {
-		log.Printf("http.ListendAndServer() failed with %s\n", err)
+	err := api.Run()
+	if err != nil {
+		log.Fatal(err)
 	}
-	log.Printf("Exited\n")
 }


### PR DESCRIPTION
Made some improvements:

* the code was always appending to the slices, never replacing them, so the lists would grow each time the status file was read
* eliminated the use of global variables in the api package
* cleaned up the parsing code, parse the status information into structs instead of generic map[string]string
* added a `/host/<hostname>/services` endpoint to retrieve the status of all services attached to a host
* Removed panics in the code, opting to return errors instead and let the upstream calling code figure out what to do

I may plan to do some other improvements like parsing the objects from the objects.cache file into structs, periodically refreshing the objects.cache data if the checksum of the file changes on disk, etc.