### PR TITLE
Thread safe function HandleGetServicesForHost.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -357,6 +357,9 @@ func (a *Api) HandleGetServicesForHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+
 	sList, ok := a.statusData.HostServices[host]
 	if !ok {
 		http.Error(w, "Host Not Found", 404)


### PR DESCRIPTION
If heavily used, sometimes the APIs go in a race condition.
This fixes this issues, locking the `Api` variable using a Mutex.
This has been tested under heavy load for a day a no race condition has happened.